### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Font options:
 - Regular font
 
   - `['300']`- will load the 300 weight
-  - `[300, 900]` - will load the 300 and 900 weights
+  - `['300', '900']` - will load the 300 and 900 weights
 
 - Variable font
   - `['200..500']` - will load the non-italic version with all weights between 200 and 500


### PR DESCRIPTION
Based on your feedback (https://github.com/pocorschi/gatsby-plugin-google-fonts-v2/issues/2#issuecomment-617062205), I updated the README to match the format of the values. It was missing the ticks around the 300 and 900.