### PR TITLE
fix: support peer dependency for gatsby v3 and v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "typescript": "^4.2.3"
   },
   "peerDependencies": {
-    "gatsby": "^4.0.0"
+    "gatsby": "^3.0.0 || ^4.0.0"
   },
   "homepage": "https://github.com/pocorschi/gatsby-plugin-google-fonts-v2",
   "keywords": [


### PR DESCRIPTION
Restoring functionality for gatsby v3 users while unblocking gatsby v4 users

Resolves: #14
Signed-off-by: Hays Clark <hays.clark@gmail.com>